### PR TITLE
chore: add typescript for type-check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "prettier": "^3.4.2",
     "tsup": "^8.3.6",
     "tsx": "^4.19.1",
+    "typescript": "^5.7.3",
     "vitest": "^2.1.3"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       tsx:
         specifier: ^4.19.1
         version: 4.19.1
+      typescript:
+        specifier: ^5.7.3
+        version: 5.7.3
       vitest:
         specifier: ^2.1.3
         version: 2.1.3(@types/node@22.7.5)


### PR DESCRIPTION
The `type-check` script expectes `tsc` to exist, but we don't actually install typescript yet as a direct dependency.

This adds typescript as a dev dependency so the type-check script works again.

CI somehow does discover `tsc` before this change, but local installs do not.