### PR TITLE
feat: add completion config support to cac

### DIFF
--- a/src/citty.ts
+++ b/src/citty.ts
@@ -3,7 +3,7 @@ import * as zsh from './zsh';
 import * as bash from './bash';
 import * as fish from './fish';
 import * as powershell from './powershell';
-import { Completion, type Handler } from '.';
+import { Completion } from './index';
 import type {
   ArgsDef,
   CommandDef,
@@ -11,6 +11,7 @@ import type {
   SubCommandsDef,
 } from 'citty';
 import { generateFigSpec } from './fig';
+import { CompletionConfig, noopHandler } from './shared';
 
 function quoteIfNeeded(path: string) {
   return path.includes(' ') ? `'${path}'` : path;
@@ -29,23 +30,6 @@ function isConfigPositional<T extends ArgsDef>(config: CommandDef<T>) {
     Object.values(config.args).some((arg) => arg.type === 'positional')
   );
 }
-
-// TODO (43081j): use type inference some day, so we can type-check
-// that the sub commands exist, the options exist, etc.
-interface CompletionConfig {
-  handler?: Handler;
-  subCommands?: Record<string, CompletionConfig>;
-  options?: Record<
-    string,
-    {
-      handler: Handler;
-    }
-  >;
-}
-
-const noopHandler: Handler = () => {
-  return [];
-};
 
 async function handleSubCommands(
   completion: Completion,

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,0 +1,18 @@
+import { Handler } from './index';
+
+export const noopHandler: Handler = () => {
+  return [];
+};
+
+// TODO (43081j): use type inference some day, so we can type-check
+// that the sub commands exist, the options exist, etc.
+export interface CompletionConfig {
+  handler?: Handler;
+  subCommands?: Record<string, CompletionConfig>;
+  options?: Record<
+    string,
+    {
+      handler: Handler;
+    }
+  >;
+}


### PR DESCRIPTION
Adds completion config support and moves some things to the shared module.

There will be a better way to share logic between these two even more but it hasn't yet clicked in my head.