### PR TITLE
fix: quote arguments for passing to auto completion server

### DIFF
--- a/src/zsh.ts
+++ b/src/zsh.ts
@@ -46,14 +46,20 @@ _${name}() {
         flagPrefix="-P \${BASH_REMATCH}"
     fi
 
-    # Prepare the command to obtain completions
-    requestComp="${exec} complete -- \${words[2,-1]}"
+    # Prepare the command to obtain completions, ensuring arguments are quoted for eval
+    local -a args_to_quote=("\${(@)words[2,-1]}")
     if [ "\${lastChar}" = "" ]; then
         # If the last parameter is complete (there is a space following it)
         # We add an extra empty parameter so we can indicate this to the go completion code.
         __${name}_debug "Adding extra empty parameter"
-        requestComp="\${requestComp} ''"
+        args_to_quote+=("")
     fi
+
+    # Use Zsh's (q) flag to quote each argument safely for eval
+    local quoted_args=("\${(@q)args_to_quote}")
+
+    # Join the main command and the quoted arguments into a single string for eval
+    requestComp="${exec} complete -- \${quoted_args[*]}"
 
     __${name}_debug "About to call: eval \${requestComp}"
 


### PR DESCRIPTION
I realized there was code in the zsh completion generation code that caused vulnerabilities.

https://github.com/bombshell-dev/tab/blob/d5659d51a87f924b08e4ba970937c3642c073cd4/src/zsh.ts#L61

Here, the `requestComp` variable contains the words that the user entered on the command line `(${words[2,-1]})`.
The eval command reinterprets this string as a shell command and executes it.

## issue point

If the user enters a string containing shell metacharacters (e.g. `;`, `&`, `|`, `$()`, etc.) as a command line argument, eval will interpret these metacharacters as command delimiters or subcommand execution with special meaning.
This may cause unintended arbitrary commands to be executed.

## example

Suppose the user types the following (name is mycli, and exec is mycli):

```sh
mycli some-command '; rm -rf ~ #'
```

In this case, `requestComp` would be a string like `“mycli complete -- some-command '; rm -rf ~ #”`. If eval executes this, the following commands may be executed in order.

As you can see, because the user input is not properly escaped or quoted, there is a risk that arbitrary commands could be injected by using `eval`.

tab case may be a rare case, but if it is input in some way, it could cause comm