### PR TITLE
fix: fallback to file completion correctly

### DIFF
--- a/src/t.ts
+++ b/src/t.ts
@@ -476,9 +476,9 @@ export class RootCommand extends Command {
   setup(name: string, executable: string, shell: string) {
     assert(
       shell === 'zsh' ||
-      shell === 'bash' ||
-      shell === 'fish' ||
-      shell === 'powershell',
+        shell === 'bash' ||
+        shell === 'fish' ||
+        shell === 'powershell',
       'Unsupported shell'
     );
 


### PR DESCRIPTION
The directive `ShellCompDirectiveNoFileComp` (value 4) is always set, which tells shells to never fall back to file completion, even when there are no completions found.

I think we should fall back to file completions whenever there is no completion is found. (for -- flag, we still don't fallback as it does not make sense) 