### PR TITLE
docs: clarify package manager completions delegate to local CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,20 @@ yarn add --emoji=<TAB>
 # Shows: true, false
 ```
 
+### Completing locally-installed CLIs
+
+Package manager completion does more than complete the package manager's own flags — it also **delegates to CLIs installed as local project dependencies**. If a CLI implements tab's completion protocol (directly or via a [framework adapter](#framework-adapters)), it becomes completable through your package manager *without* being on your `PATH` and without installing its completion script separately:
+
+```bash
+pnpm exec my-cli <TAB>      # completes my-cli's subcommands and flags
+pnpm dlx my-cli <TAB>
+pnpm my-cli <TAB>           # the bare form works too
+```
+
+Under the hood, tab strips the package-manager wrapper (`exec`, `x`, `run`, `dlx`), detects whether the target CLI supports completion, and forwards the request to it — falling back to running the CLI *through* the package manager (e.g. `pnpm my-cli complete -- …`) so locally-installed binaries resolve. The same works for `npm exec`, `yarn`, and `bun x`.
+
+> **Note:** Completion is registered against the package-manager binary (`npm`, `pnpm`, `yarn`, `bun`). `npx` and `bunx` are separate commands with no completion of their own, so `npx my-cli <TAB>` / `bunx my-cli <TAB>` won't complete — use `npm exec my-cli` / `bun x my-cli` instead.
+
 ## Framework Adapters
 
 tab provides adapters for popular JavaScript CLI frameworks.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ yarn add --emoji=<TAB>
 
 ### Completing locally-installed CLIs
 
-Package manager completion does more than complete the package manager's own flags — it also **delegates to CLIs installed as local project dependencies**. If a CLI implements tab's completion protocol (directly or via a [framework adapter](#framework-adapters)), it becomes completable through your package manager *without* being on your `PATH` and without installing its completion script separately:
+Package manager completion does more than complete the package manager's own flags — it also **delegates to CLIs installed as local project dependencies**. If a CLI implements tab's completion protocol (directly or via a [framework adapter](#framework-adapters)), it becomes completable through your package manager _without_ being on your `PATH` and without installing its completion script separately:
 
 ```bash
 pnpm exec my-cli <TAB>      # completes my-cli's subcommands and flags
@@ -166,7 +166,7 @@ pnpm dlx my-cli <TAB>
 pnpm my-cli <TAB>           # the bare form works too
 ```
 
-Under the hood, tab strips the package-manager wrapper (`exec`, `x`, `run`, `dlx`), detects whether the target CLI supports completion, and forwards the request to it — falling back to running the CLI *through* the package manager (e.g. `pnpm my-cli complete -- …`) so locally-installed binaries resolve. The same works for `npm exec`, `yarn`, and `bun x`.
+Under the hood, tab strips the package-manager wrapper (`exec`, `x`, `run`, `dlx`), detects whether the target CLI supports completion, and forwards the request to it — falling back to running the CLI _through_ the package manager (e.g. `pnpm my-cli complete -- …`) so locally-installed binaries resolve. The same works for `npm exec`, `yarn`, and `bun x`.
 
 > **Note:** Completion is registered against the package-manager binary (`npm`, `pnpm`, `yarn`, `bun`). `npx` and `bunx` are separate commands with no completion of their own, so `npx my-cli <TAB>` / `bunx my-cli <TAB>` won't complete — use `npm exec my-cli` / `bun x my-cli` instead.
 


### PR DESCRIPTION
## What

The README's **Package Manager Completions** section only shows completing the package manager's *own* flags (e.g. `pnpm install --reporter=<TAB>`). It doesn't mention what's arguably the most useful behavior: package-manager completion also **delegates to CLIs installed as local project dependencies**.

When a user has `tab pnpm zsh` (etc.) installed, typing `pnpm exec my-cli <TAB>` completes `my-cli`'s own subcommands and flags — even though `my-cli` isn't on `PATH` and the user never installed its completion script. This isn't documented anywhere, so CLI authors and users don't know it works.

## Why

This came up while documenting completions for [varlock](https://varlock.dev). Our docs initially (incorrectly) told users that completion "won't work when installed as a local dependency." You told me on discord and I confirmed in the code that is not true — the package-manager completion strips `exec`/`x`/`run`/`dlx`, detects whether the target CLI speaks the completion protocol, and forwards the request (falling back to `<pm> <cli> complete -- …` so local binaries resolve).

## Changes

Adds a **Completing locally-installed CLIs** subsection that:
- shows the `pnpm exec` / `dlx` / bare forms
- briefly explains the delegation mechanism
- notes the genuine exception: `npx` / `bunx` are separate binaries with no completion of their own, so those forms don't work — use `npm exec` / `bun x` instead

Docs-only change.