### PR TITLE
fix: invoke cli by program name in generated completion scripts

### DIFF
--- a/.changeset/two-teeth-hug.md
+++ b/.changeset/two-teeth-hug.md
@@ -1,0 +1,5 @@
+---
+'@bomb.sh/tab': patch
+---
+
+fix: invoke the cli by its program name in generated completion scripts

--- a/src/cac.ts
+++ b/src/cac.ts
@@ -9,18 +9,9 @@ import t, { type RootCommand } from './t';
 
 const execPath = process.execPath;
 const processArgs = process.argv.slice(1);
-const quotedExecPath = quoteIfNeeded(execPath);
-const quotedProcessArgs = processArgs.map(quoteIfNeeded);
-const quotedProcessExecArgs = process.execArgv.map(quoteIfNeeded);
-
-const x = `${quotedExecPath} ${quotedProcessExecArgs.join(' ')} ${quotedProcessArgs[0]}`;
 
 // Regex to detect if an option takes a value (has <required> or [optional] parameters)
 const VALUE_OPTION_RE = /<[^>]+>|\[[^\]]+\]/;
-
-function quoteIfNeeded(path: string): string {
-  return path.includes(' ') ? `'${path}'` : path;
-}
 
 export default async function tab(
   instance: CAC,
@@ -122,24 +113,27 @@ export default async function tab(
   }
 
   instance.command('complete [shell]').action(async (shell, extra) => {
+    // invoke the cli by its program name so completion works regardless of how
+    // the cli is launched (including compiled binaries). see the related issue #135
+    const execCommand = instance.name;
     switch (shell) {
       case 'zsh': {
-        const script = zsh.generate(instance.name, x);
+        const script = zsh.generate(instance.name, execCommand);
         console.log(script);
         break;
       }
       case 'bash': {
-        const script = bash.generate(instance.name, x);
+        const script = bash.generate(instance.name, execCommand);
         console.log(script);
         break;
       }
       case 'fish': {
-        const script = fish.generate(instance.name, x);
+        const script = fish.generate(instance.name, execCommand);
         console.log(script);
         break;
       }
       case 'powershell': {
-        const script = powershell.generate(instance.name, x);
+        const script = powershell.generate(instance.name, execCommand);
         console.log(script);
         break;
       }

--- a/src/citty.ts
+++ b/src/citty.ts
@@ -15,17 +15,6 @@ import { assertDoubleDashes } from './shared';
 import type { CompletionConfig } from './shared';
 import t, { type RootCommand } from './t';
 
-function quoteIfNeeded(path: string) {
-  return path.includes(' ') ? `'${path}'` : path;
-}
-
-const execPath = process.execPath;
-const processArgs = process.argv.slice(1);
-const quotedExecPath = quoteIfNeeded(execPath);
-const quotedProcessArgs = processArgs.map(quoteIfNeeded);
-const quotedProcessExecArgs = process.execArgv.map(quoteIfNeeded);
-const x = `${quotedExecPath} ${quotedProcessExecArgs.join(' ')} ${quotedProcessArgs[0]}`;
-
 function isConfigPositional<T extends ArgsDef>(config: CommandDef<T>) {
   return (
     config.args &&
@@ -200,24 +189,27 @@ export default async function tab<TArgs extends ArgsDef>(
         shell = undefined;
       }
 
+      // the cli by its program name so completion works regardless of
+      // how the cli is launched (including compiled binaries). see the related issue #135
+      const execCommand = name;
       switch (shell) {
         case 'zsh': {
-          const script = zsh.generate(name, x);
+          const script = zsh.generate(name, execCommand);
           console.log(script);
           break;
         }
         case 'bash': {
-          const script = bash.generate(name, x);
+          const script = bash.generate(name, execCommand);
           console.log(script);
           break;
         }
         case 'fish': {
-          const script = fish.generate(name, x);
+          const script = fish.generate(name, execCommand);
           console.log(script);
           break;
         }
         case 'powershell': {
-          const script = powershell.generate(name, x);
+          const script = powershell.generate(name, execCommand);
           console.log(script);
           break;
         }

--- a/src/citty.ts
+++ b/src/citty.ts
@@ -189,8 +189,8 @@ export default async function tab<TArgs extends ArgsDef>(
         shell = undefined;
       }
 
-      // the cli by its program name so completion works regardless of
-      // how the cli is launched (including compiled binaries). see the related issue #135
+      // invoke the cli by its program name so completion works regardless of how
+      // the cli is launched (including compiled binaries). see the related issue #135
       const execCommand = name;
       switch (shell) {
         case 'zsh': {

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -6,18 +6,6 @@ interface CommandWithRawArgs extends CommanderCommand {
   rawArgs: string[];
 }
 
-const execPath = process.execPath;
-const processArgs = process.argv.slice(1);
-const quotedExecPath = quoteIfNeeded(execPath);
-const quotedProcessArgs = processArgs.map(quoteIfNeeded);
-const quotedProcessExecArgs = process.execArgv.map(quoteIfNeeded);
-
-const x = `${quotedExecPath} ${quotedProcessExecArgs.join(' ')} ${quotedProcessArgs[0]}`;
-
-function quoteIfNeeded(path: string): string {
-  return path.includes(' ') ? `'${path}'` : path;
-}
-
 export default function tab(
   instance: CommanderCommand,
   completionConfig?: { completionCommandName?: string }
@@ -36,7 +24,8 @@ export default function tab(
         .choices(['zsh', 'bash', 'fish', 'powershell'])
     )
     .action((shell) => {
-      t.setup(programName, x, shell);
+      // invoke the cli by its program name and not the runtime launch path. see the related issue #135.
+      t.setup(programName, programName, shell);
     });
   completionCommand.copyInheritedSettings(instance);
 

--- a/tests/completion-exec.test.ts
+++ b/tests/completion-exec.test.ts
@@ -1,0 +1,77 @@
+import { exec } from 'node:child_process';
+import { describe, it, expect } from 'vitest';
+
+// Verifies the command that generated completion scripts invoke to request
+// suggestions. Completion is triggered by the shell only once the command name
+// is resolvable (via PATH, an alias, or a shell function), so the script should
+// invoke the CLI by its plain program name rather than a reconstructed,
+// runtime-specific launch path. Baking in a launch path makes the script
+// depend on how the CLI happened to be started, which does not hold across
+// runtimes (e.g. compiled single-file binaries).
+
+function run(command: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    exec(command, { cwd: process.cwd() }, (error, stdout, stderr) => {
+      if (error) reject(new Error(stderr || String(error)));
+      else resolve(stdout);
+    });
+  });
+}
+
+// Pull out the command the generated script will exec to request completions
+// (the value baked in as `requestComp` / `$RequestComp`), across every shell.
+function extractExecCommand(shell: string, script: string): string | null {
+  let match: RegExpMatchArray | null = null;
+  switch (shell) {
+    case 'zsh':
+    case 'bash':
+      match = script.match(/requestComp="(.+?) complete --/);
+      break;
+    case 'fish':
+      match = script.match(/set -l requestComp "(.+?) complete --/);
+      break;
+    case 'powershell':
+      match = script.match(/\$RequestComp = "& (.+?) complete '--'/);
+      break;
+  }
+  return match ? match[1] : null;
+}
+
+const adapters = [
+  { adapter: 'commander', programName: 'myapp' },
+  { adapter: 'cac', programName: 'vite' },
+  { adapter: 'citty', programName: 'vite' },
+] as const;
+
+const shells = ['zsh', 'bash', 'fish', 'powershell'] as const;
+
+describe('generated completion scripts invoke the CLI by program name', () => {
+  for (const { adapter, programName } of adapters) {
+    describe(`${adapter} adapter`, () => {
+      for (const shell of shells) {
+        it(`${shell}: requestComp uses the program name, not a runtime launch path`, async () => {
+          const script = await run(
+            `pnpm tsx examples/demo.${adapter}.ts complete ${shell}`
+          );
+
+          const execCommand = extractExecCommand(shell, script);
+          expect(
+            execCommand,
+            `could not locate requestComp in generated ${shell} script`
+          ).not.toBeNull();
+
+          // The command baked into the script must be exactly the program name.
+          expect(execCommand).toBe(programName);
+
+          // A bare program name never contains any of these substrings, so
+          // their presence signals a runtime-specific launch path leaking in.
+          expect(execCommand).not.toContain('/');
+          expect(execCommand).not.toContain('node');
+          expect(execCommand).not.toContain('tsx');
+          expect(execCommand).not.toContain('$bunfs');
+          expect(execCommand).not.toContain('.ts');
+        });
+      }
+    });
+  }
+});


### PR DESCRIPTION
closes #135 

The adapters baked a reconstructed launch path (`process.execPath` + `execArgv` + `argv[1]`) into the generated completion scripts, which assumes a `node/bun script.js` invocation. That path is invalid for compiled single-file binaries (`bun build --compile`, Node SEA, etc.), where `argv[1]` is a virtual/duplicated path and this silently breaking tab completion. the commander, cac, and citty adapters now invoke the CLI by its program name, which the shell already resolves via PATH/alias/function.
